### PR TITLE
Smardex (USDN): Fix USDN Protocol APR calculation

### DIFF
--- a/src/adaptors/smardex/index.js
+++ b/src/adaptors/smardex/index.js
@@ -134,6 +134,14 @@ const EXCEPTIONS = {
             })
           ).output / 1e18;
         const apyBase = await computeUsdnApr();
+        console.log({
+          pool: USDN_TOKEN_ADDRESS,
+          symbol: 'USDN',
+          project: 'smardex',
+          chain: utils.formatChain(chainString),
+          tvlUsd: totalSupply,
+          apyBase,
+        });
         return {
           pool: USDN_TOKEN_ADDRESS,
           symbol: 'USDN',
@@ -567,7 +575,7 @@ async function fetchUSDNData(chain, timestamp) {
   });
 
   const wstEthPrice = await getWstEthPriceAtTimestamp(chain, timestamp);
-  const formattedWstEthPrice = BigInt(Math.round(wstEthPrice * 10 ** 8));
+  const formattedWstEthPrice = BigInt(Math.round(wstEthPrice * 10 ** 18));
 
   const usdnVaultAssetAvailableWithFundingCall = sdk.api.abi.call({
     target: USDN_PROTOCOL_ADDRESS,
@@ -634,8 +642,7 @@ const computeUsdnApr = async (chain = 'ethereum') => {
       BIGINT_10_POW_18) *
       BigInt(DAYS_IN_YEAR)) /
     (BigInt(timestampNow) - BigInt(timestampOneYearAgo));
-
-  return Number(formatEther(apr));
+  return Number(formatEther(apr) * 100_000);
 };
 
 module.exports = {


### PR DESCRIPTION
- I fixed the APR: there was a decimal issue with wstETH (18 instead of 8).
- The percentages weren’t correctly formatted for DefiLlama, it’s fixed now.

I noticed a 2-5% difference with the percentage calculated on the website. 
I’ll double-check with a backend dev today to confirm it’s just the source of the wstETH price (DefiLlama vs Pyth).

**Current APR**
```ts
{
  pool: '0xde17a000BA631c5d7c2Bd9FB692EFeA52D90DEE2',
  symbol: 'USDN',
  project: 'smardex',
  chain: 'Ethereum',
  tvlUsd: 3042305.789094045,
  apyBase: 0.5804868296606
}
```
**APR 7 Days ago**
```ts
{
  pool: '0xde17a000BA631c5d7c2Bd9FB692EFeA52D90DEE2',
  symbol: 'USDN',
  project: 'smardex',
  chain: 'Ethereum',
  tvlUsd: 3042305.789094045,
  apyBase: 0.7589396478978999
}
```